### PR TITLE
[WIP] Update to DataFrames 0.11

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,5 @@ julia 0.6.0
 Distributions 0.4.6
 StatsBase 0.7.1
 DataArrays 0.5.0
-DataFrames 0.9
+DataFrames 0.11
+StatsModels 0.1

--- a/src/FixedEffectModels.jl
+++ b/src/FixedEffectModels.jl
@@ -11,7 +11,8 @@ import Base.BLAS: axpy!
 import Base: A_mul_B!, Ac_mul_B!, size, copy!, getindex, length, fill!, norm, scale!, eltype, length, view, start, next, done
 import Distributions: TDist, ccdf, FDist, Chisq, AliasTable, Categorical
 import DataArrays: RefArray, PooledDataArray, PooledDataVector, DataArray, DataVector, compact, NAtype
-import DataFrames: DataFrame, AbstractDataFrame, ModelMatrix, ModelFrame, Terms, coefnames, Formula, completecases, names!, pool, @formula
+import DataFrames: DataFrame, AbstractDataFrame, coefnames, completecases, names!, pool
+import StatsModels: ModelMatrix, ModelFrame, Terms, @formula, Formula
 import StatsBase: coef, nobs, coeftable, vcov, predict, residuals, var, RegressionModel, model_response, stderr, confint, fit, CoefTable, df_residual
 ##############################################################################
 ##


### PR DESCRIPTION
Model specifications have moved out of `DataFrames` to [`StatModels`](https://github.com/JuliaStats/StatsModels.jl). 
Passes tests locally.

I'm not an expert, but perhaps this package needs a new tag before updating the `REQUIRE` file?