### PR TITLE
Add `dof_residual` method to comply better with StatsBase API

### DIFF
--- a/src/FixedEffectModels.jl
+++ b/src/FixedEffectModels.jl
@@ -21,7 +21,7 @@ import CategoricalArrays: CategoricalArray, CategoricalVector, compress, categor
 import DataFrames: DataFrame, AbstractDataFrame, completecases, names!, ismissing
 import Combinatorics: combinations
 using Reexport
-import StatsBase: coef, nobs, coeftable, vcov, predict, residuals, var, RegressionModel, model_response, stderror, confint, fit, CoefTable, df_residual, r2, adjr2
+import StatsBase: coef, nobs, coeftable, vcov, predict, residuals, var, RegressionModel, model_response, stderror, confint, fit, CoefTable, df_residual, dof_residual, r2, adjr2
 @reexport using StatsBase
 import StatsModels: @formula,  Formula, ModelFrame, ModelMatrix, Terms, coefnames, evalcontrasts, check_non_redundancy!
 ##############################################################################

--- a/src/RegressionResult.jl
+++ b/src/RegressionResult.jl
@@ -249,13 +249,13 @@ end
 
 title(::RegressionResultIV) = "IV Model"
 top(x::RegressionResultIV) = [
-            "Number of obs" sprint(show, nobs(x), contect = :compact => true);
-            "Degrees of freedom" sprint(show, nobs(x) - df_residual(x), contect = :compact => true);
+            "Number of obs" sprint(show, nobs(x), context = :compact => true);
+            "Degrees of freedom" sprint(show, nobs(x) - df_residual(x), context = :compact => true);
             "R2" format_scientific(x.r2);
             "R2 Adjusted" format_scientific(x.r2_a);
-            "F-Statistic" sprint(show, x.F, contect = :compact => true);
+            "F-Statistic" sprint(show, x.F, context = :compact => true);
             "p-value" format_scientific(x.p);
-            "First Stage F-stat (KP)" sprint(show, x.F_kp, contect = :compact => true);
+            "First Stage F-stat (KP)" sprint(show, x.F_kp, context = :compact => true);
             "First Stage p-val (KP)" format_scientific(x.p_kp);
             ]
 

--- a/src/RegressionResult.jl
+++ b/src/RegressionResult.jl
@@ -16,7 +16,8 @@ df_residual(x::AbstractRegressionResult) = x.df_residual
 r2(x::AbstractRegressionResult) = x.r2
 adjr2(x::AbstractRegressionResult) = x.r2_a
 
-
+# Compliance with RegressionModel API (partial implementation)
+dof_residual(x::AbstractRegressionResult) = df_residual(x)
 
 function confint(x::AbstractRegressionResult) 
     scale = quantile(TDist(x.df_residual), 1 - (1-0.95)/2)


### PR DESCRIPTION
Currently FixedEffectModels does not adhere to the updated StatsBase: RegressionModel API since it implements `df_residual` instead of `dof_residual` (at some point there must have been a decision to change the names).  This PR adds a `dof_residual` method that simply wraps a call to `df_residual` in order to use `AbstractRegressionResult` types in other packages that expect `dof_residual` to be defined.  