### PR TITLE
Separate `save` into `savefe` and `saveresid`

### DIFF
--- a/src/reg.jl
+++ b/src/reg.jl
@@ -291,7 +291,7 @@ function reg(df::AbstractDataFrame, f::Formula;
             augmentdf[esample, :residuals] = residuals ./ sqrtw 
         end
     end
-    if save
+    if save || savefe
         if has_absorb
             if !all(basecoef)
                 oldX = oldX[:, basecoef]


### PR DESCRIPTION
I'm running into situations where you'd like to save the residuals, but you do not want to get the estimated FE's (which is costly), so I've separated `save` into `savefe` and `saveresid` (but kept `save` to ensure backward compatibility).
