### PR TITLE
Update and test multiway clustering algorithm

### DIFF
--- a/src/vcov/vcovcluster.jl
+++ b/src/vcov/vcovcluster.jl
@@ -11,7 +11,7 @@ struct VcovClusterMethod <: AbstractVcovMethod
 end
 
 
-function VcovMethod(df::AbstractDataFrame, vcovcluster::VcovClusterFormula) 
+function VcovMethod(df::AbstractDataFrame, vcovcluster::VcovClusterFormula)
     clusters = vcovcluster._
     vclusters = DataFrame(Vector, size(df, 1), 0)
     for c in clusters
@@ -42,20 +42,34 @@ function shat!(v::VcovClusterMethod, x::VcovData{T, N}) where {T, N}
     # Cameron, Gelbach, & Miller (2011).
     dim = size(x.regressors, 2) * size(x.residuals, 2)
     S = fill(zero(Float64), (dim, dim))
+    iter=1
+    G=0
     for c in combinations(names(v.clusters))
+        @show c, length(c)
         if length(c) == 1
+            println("no group")
             # no need for group
             f = v.clusters[c[1]]
         else
+            println("grouping...")
             f = group((v.clusters[var] for var in c)...)
         end
+        if iter==1
+            G = length(f.pool)
+            iter +=1
+        elseif length(f.pool) < G
+            G = length(f.pool)
+        end
         if rem(length(c), 2) == 1
+            println("length(c) is odd, adding to V2way")
             S += helper_cluster(x.regressors, x.residuals, f)
         else
+            println("length(c) is even, subtracting from V2way")
             S -= helper_cluster(x.regressors, x.residuals, f)
         end
     end
-    rmul!(S, (size(x.regressors, 1) - 1) / x.dof_residual)
+    println("($size(x.regressors, 1) - 1) / $(x.dof_residual) ) * ($G / $G - 1) ")
+    rmul!(S, ( (size(x.regressors, 1) - 1) / x.dof_residual ) * ( G / (G - 1) ) ) # ((N-1)/(N-K)) * (G/(G-1))
     return S
 end
 
@@ -65,6 +79,7 @@ end
 function helper_cluster(X::Matrix{Float64}, res::Union{Vector{Float64}, Matrix{Float64}}, f::CategoricalVector)
     dim = size(X, 2) * size(res, 2)
     X2 = fill(zero(Float64), length(f.pool), dim)
+    @show length(f.pool), size(X2)
     index = 0
     for k in 1:size(res, 2)
         for j in 1:size(X, 2)
@@ -75,11 +90,13 @@ function helper_cluster(X::Matrix{Float64}, res::Union{Vector{Float64}, Matrix{F
         end
     end
     S2 = X2' * X2
-    if length(f.pool) < size(X, 1)
+    @show size(X)
+    #if length(f.pool) < size(X, 1) # reghdfe applies a transformation to the final S, not to these intermediate S components
         # if only one obs by pool, for instance cluster(year state)
-        # use White, as in Petersen (2009) & Thomson (2011) 
-        rmul!(S2, length(f.pool) / (length(f.pool) - 1))
-    end
+        # use White, as in Petersen (2009) & Thomson (2011)
+    #    println("using rmul!")
+    #    rmul!(S2, length(f.pool) / (length(f.pool) - 1))
+    #end
     return S2
 end
 

--- a/src/vcov/vcovcluster.jl
+++ b/src/vcov/vcovcluster.jl
@@ -42,7 +42,7 @@ function shat!(v::VcovClusterMethod, x::VcovData{T, N}) where {T, N}
     # Cameron, Gelbach, & Miller (2011): section 2.3
     dim = size(x.regressors, 2) * size(x.residuals, 2)
     S = fill(zero(Float64), (dim, dim))
-    iter=1; G=0
+    iter=1; G=typemax(Int64)
     for c in combinations(names(v.clusters))
         if length(c) == 1
             # no need for group
@@ -51,12 +51,7 @@ function shat!(v::VcovClusterMethod, x::VcovData{T, N}) where {T, N}
             f = group((v.clusters[var] for var in c)...)
         end
         # capture length of smallest dimension of multiway clustering in G
-        if iter==1
-            G = length(f.pool)
-            iter +=1
-        elseif length(f.pool) < G
-            G = length(f.pool)
-        end
+        G = min(G, length(f.pool))
         if rem(length(c), 2) == 1
             S += helper_cluster(x.regressors, x.residuals, f)
         else

--- a/test/reg.jl
+++ b/test/reg.jl
@@ -252,21 +252,23 @@ x = reg(df, m)
 m = @model y ~ (x1 ~z1) fe = pid1 vcov = cluster(pid1) weights = w
 x = reg(df, m)
 @test stderror(x) ≈ [0.0337439] atol = 1e-7
-
+### Tests below are modified to match reghdfe. Clean up before PR.
 # TO CHECK WITH STATA
 m = @model y ~ x1 vcov = cluster(pid1 + pid2)
 x = reg(df, m)
-@test stderror(x)[1] ≈ 6.170255 atol = 1e-4
+@test stderror(x) ≈ [6.196362, 0.0403469] atol = 1e-6
 # TO CHECK WITH STATA
 m = @model y ~ x1 fe = pid1 vcov = cluster(pid1 + pid2)
 x = reg(df, m)
-@test stderror(x)[1] ≈ 0.04037 atol = 1e-4
+@test stderror(x) ≈ [0.0405335] atol = 1e-7
 
 # TO CHECK WITH STATA
-m = @model y ~ x1 fe = pid1 vcov = cluster(pid1&pid2)
+m = @model y ~ x1 fe = pid1 vcov = cluster(pid2&pid1)
 x = reg(df, m)
-@test stderror(x) ≈ [0.0110005] atol = 1e-4
+@test stderror(x) ≈ [0.0110005] atol = 1e-7
 
+m=@model y ~ x1 + pid1 vcov=cluster(pid1&pid2)
+x = reg(df, m, df_add=1)
 
 @test_throws ErrorException reg(df, @model(y ~ x1, vcov = cluster(State)))
 

--- a/test/reg.jl
+++ b/test/reg.jl
@@ -401,22 +401,28 @@ x = reg(df, m)
 
 
 
-# like in ivreg2 but += 5 difference. there is a degrees of freedom difference. not sure where.
+# like in ivreg2 but += 5 difference. combination iv difference, degrees of freedom difference?
+# iv + cluster - F_kp varies from ivreg2 about 7e-4 (SEs off by more than 2 df)
 m = @model y ~ (x1 ~ z1) vcov = cluster(pid1)
 x = reg(df, m)
 @test x.F_kp     ≈ 7249.88606 atol = 1e-4
+# iv + cluster - F_kp varies from ivreg2 about 5e-6 (SEs off by more than 2 df)
 m = @model y ~ CPI + (x1 ~ z1) vcov = cluster(pid1)
 x = reg(df, m)
 @test x.F_kp   ≈ 538.40393 atol = 1e-4
+# Modified test values below after multiway clustering update
+# iv + 2way clustering - F_kp matches ivreg2 (SEs match with df_add=-2)
 m = @model y ~ CPI + (x1 ~ z1) vcov = cluster(pid1 + pid2)
 x = reg(df, m)
-@test x.F_kp   ≈ 423.003425 atol = 1e-4
+@test x.F_kp   ≈ 421.9651 atol = 1e-4
+# multivariate iv + clustering - F_kp varies from ivreg2 about 3 (SEs off by more than 2 df)
 m = @model y ~ (x1 ~ z1 + CPI) vcov = cluster(pid1)
 x = reg(df, m)
 @test x.F_kp      ≈ 4080.66081 atol = 1e-4
+# multivariate iv + multiway clustering - F_kp varies from ivreg2 about 2 (SEs off by more than 2 df)
 m = @model y ~ (x1 ~ z1 + CPI) vcov = cluster(pid1 + pid2)
 x = reg(df, m)
-@test x.F_kp  ≈ 2877.9447778 atol = 1e-4
+@test x.F_kp  ≈ 2873.1405 atol = 1e-4
 
 
 

--- a/test/reg.jl
+++ b/test/reg.jl
@@ -98,6 +98,8 @@ x = reg(df, m)
 @test coef(x) ≈ [- 0.461085492] atol = 1e-4
 
 # iv
+# Stata consistency: coefficient estimates match ivreg2/ivreghdfe
+# Standard error estimates do not match for iv models. See lines 213, 227
 m = @model y ~ (x1 ~ z1)
 x = reg(df, m)
 @test coef(x) ≈ [138.19479,- 0.20733] atol = 1e-4
@@ -204,72 +206,80 @@ x = reg(df, m)
 ##
 ##############################################################################
 
-# Simple
+# Simple - matches stata
 m = @model y ~ x1
 x = reg(df, m)
-@test stderror(x) ≈ [1.52126, 0.01889] atol = 1e-4
-# Stata ivreg
+@test stderror(x) ≈ [1.521269, 0.0188963] atol = 1e-6
+# Stata ivreg - ivreg2 discrepancy - matches with df_add=-2
 m = @model y ~ (x1 ~ z1)
 x = reg(df, m)
 @test stderror(x) ≈ [1.53661, 0.01915] atol = 1e-4
 # Stata areg
 m = @model y ~ x1 fe = pid1
 x = reg(df, m)
-@test stderror(x) ≈  [0.00980] atol = 1e-4
+@test stderror(x) ≈  [0.0098003] atol = 1e-7
 
 # White
-# Stata reg
+# Stata reg - matches stata
 m = @model y ~ x1 vcov = robust
 x = reg(df, m)
-@test stderror(x) ≈ [1.68679, 0.01670] atol = 1e-4
-# Stata ivreg
+@test stderror(x) ≈ [1.686791, 0.0167042] atol = 1e-6
+# Stata ivreg - ivreg2 discrepancy - matches with df_add=-2
 m = @model y ~ (x1 ~ z1) vcov = robust
 x = reg(df, m)
 @test stderror(x) ≈ [1.63305, 0.01674] atol = 1e-4
-# Stata areg
+# Stata areg - matches areg
 m = @model y ~ x1 fe = pid1 vcov = robust
-x = reg(df, m)
-@test stderror(x) ≈ [0.01100] atol = 1e-4
-
-# cluster
-m = @model y ~ x1 vcov = cluster(pid1)
-x = reg(df, m)
-@test stderror(x)[2] ≈ 0.03792 atol = 1e-4
-m = @model y ~ x1 fe = pid1 vcov = cluster(pid2)
-x = reg(df, m)
-@test stderror(x) ≈ [0.02205] atol = 1e-4
-# stata reghxe
-m = @model y ~ x1 fe = pid1 vcov = cluster(pid1)
-x = reg(df, m)
-@test stderror(x) ≈ [0.0357498] atol = 1e-7
-## compare the two bewlo with reghdfe
-m = @model y ~ x2 + (x1 ~z1) fe = pid1 vcov = cluster(pid1)
-x = reg(df, m)
-@test stderror(x) ≈ [0.0019704, 0.1893396] atol = 1e-7
-m = @model y ~ x2 + (x1 ~z1) fe = pid1 vcov = cluster(pid1) weights = w
-x = reg(df, m)
-@test stderror(x) ≈ [0.000759, 0.070836] atol = 1e-6
-m = @model y ~ (x1 ~z1) fe = pid1 vcov = cluster(pid1) weights = w
-x = reg(df, m)
-@test stderror(x) ≈ [0.0337439] atol = 1e-7
-### Tests below are modified to match reghdfe. Clean up before PR.
-# TO CHECK WITH STATA
-m = @model y ~ x1 vcov = cluster(pid1 + pid2)
-x = reg(df, m)
-@test stderror(x) ≈ [6.196362, 0.0403469] atol = 1e-6
-# TO CHECK WITH STATA
-m = @model y ~ x1 fe = pid1 vcov = cluster(pid1 + pid2)
-x = reg(df, m)
-@test stderror(x) ≈ [0.0405335] atol = 1e-7
-
-# TO CHECK WITH STATA
-m = @model y ~ x1 fe = pid1 vcov = cluster(pid2&pid1)
 x = reg(df, m)
 @test stderror(x) ≈ [0.0110005] atol = 1e-7
 
+# Clustering models
+# cluster - matches stata
+m = @model y ~ x1 vcov = cluster(pid1)
+x = reg(df, m)
+@test stderror(x)[2] ≈ 0.0379228 atol = 1e-7
+# cluster with fe - matches areg & reghdfe
+m = @model y ~ x1 fe = pid1 vcov = cluster(pid2)
+x = reg(df, m)
+@test stderror(x) ≈ [0.0220563] atol = 1e-7
+# stata reghxe - matches reghdfe (not areg)
+m = @model y ~ x1 fe = pid1 vcov = cluster(pid1)
+x = reg(df, m)
+@test stderror(x) ≈ [0.0357498] atol = 1e-7
+# iv + fe + cluster - matches ivreghdfe
+m = @model y ~ x2 + (x1 ~z1) fe = pid1 vcov = cluster(pid1)
+x = reg(df, m)
+@test stderror(x) ≈ [0.0019704, 0.1893396] atol = 1e-7
+# iv + fe + cluster + weights - matches ivreghdfe
+m = @model y ~ x2 + (x1 ~z1) fe = pid1 vcov = cluster(pid1) weights = w
+x = reg(df, m)
+@test stderror(x) ≈ [0.000759, 0.070836] atol = 1e-6
+# iv + fe + cluster + weights - matches ivreghdfe
+m = @model y ~ (x1 ~z1) fe = pid1 vcov = cluster(pid1) weights = w
+x = reg(df, m)
+@test stderror(x) ≈ [0.0337439] atol = 1e-7
+# multiway clustering - matches reghdfe
+m = @model y ~ x1 vcov = cluster(pid1 + pid2)
+x = reg(df, m)
+@test stderror(x) ≈ [6.196362, 0.0403469] atol = 1e-6
+# fe + multiway clustering - matches reghdfe
+m = @model y ~ x1 fe = pid1 vcov = cluster(pid1 + pid2)
+x = reg(df, m)
+@test stderror(x) ≈ [0.0405335] atol = 1e-7
+# fe + clustering on interactions - matches reghdfe
+m = @model y ~ x1 fe = pid1 vcov = cluster(pid1&pid2)
+x = reg(df, m)
+@test stderror(x) ≈ [0.0110005] atol = 1e-7
+# fe partially nested in interaction clusters - matches reghdfe
+m=@model y ~ x1 fe = pid1 vcov=cluster(pid1&pid2)
+x = reg(df, m)
+@test stderror(x) ≈ [0.0110005] atol = 1e-7
+# regressor partially nested in interaction clusters - matches reghdfe
 m=@model y ~ x1 + pid1 vcov=cluster(pid1&pid2)
-x = reg(df, m, df_add=1)
+x = reg(df, m)
+@test stderror(x)[1:2] ≈ [3.032187, 0.0110005] atol=1e-5
 
+# catch continuous variable in cluster
 @test_throws ErrorException reg(df, @model(y ~ x1, vcov = cluster(State)))
 
 ##############################################################################


### PR DESCRIPTION
Re [issue 49](https://github.com/matthieugomez/FixedEffectModels.jl/issues/49).

Rewrites multiway clustering to match approach used by reghdfe. (Smallest-length cluster adjustment for variance-covariance matrix, as in Cameron Gelbach & Miller 2011, section 2.3.)