### PR TITLE
Add fe(s::Symbol) for programmatic formula construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ reg(df, @formula(Sales ~ NDI + fe(State) + fe(Year)), Vcov.cluster(:State), weig
 
 	To construct formula programatically, use
 	```julia
-	reg(df, Term(:Sales) ~ Term(:NDI) + fe(Term(:State)) + fe(Term(:Year)))
+	reg(df, term(:Sales) ~ term(:NDI) + fe(:State) + fe(:Year))
 	```
 
 - Standard errors are indicated with the prefix `Vcov`.

--- a/src/utils/formula.jl
+++ b/src/utils/formula.jl
@@ -47,6 +47,7 @@ struct FixedEffectTerm <: AbstractTerm
 end
 StatsModels.termvars(t::FixedEffectTerm) = [t.x]
 fe(x::Term) = FixedEffectTerm(Symbol(x))
+fe(s::Symbol) = FixedEffectTerm(s)
 
 has_fe(::FixedEffectTerm) = true
 has_fe(::FunctionTerm{typeof(fe)}) = true

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -213,7 +213,8 @@ x = reg(df, m)
 ## Programming
 ##
 ##############################################################################
-reg(df, Term(:Sales) ~ Term(:NDI) + fe(Term(:State)) + fe(Term(:Year)), Vcov.cluster(:State))
+reg(df, term(:Sales) ~ term(:NDI) + fe(:State) + fe(:Year), Vcov.cluster(:State))
+fe(:State) + fe(:Year) === reduce(+, fe.([:State, :Year])) === fe(Term(:State)) + fe(Term(:Year))
 
 
 ##############################################################################

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -214,7 +214,7 @@ x = reg(df, m)
 ##
 ##############################################################################
 reg(df, term(:Sales) ~ term(:NDI) + fe(:State) + fe(:Year), Vcov.cluster(:State))
-fe(:State) + fe(:Year) === reduce(+, fe.([:State, :Year])) === fe(Term(:State)) + fe(Term(:Year))
+@test fe(:State) + fe(:Year) === reduce(+, fe.([:State, :Year])) === fe(Term(:State)) + fe(Term(:Year))
 
 
 ##############################################################################


### PR DESCRIPTION
When constructing a formula programmatically, calling `Term` inside `fe` is verbose. It seems that nothing is relying on having an `AbstractTerm` to be called by `fe`. So, I suggest simplifying the syntax by directly passing the Symbol `s` to `fe`.

It is also easier to add multiple fixed effects from an array like this: `reduce(+, fe.([:State, :Year]))`.
