### PR TITLE
Improve parse_fixedeffect for general usage

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,21 +1,23 @@
-name = "FixedEffectModels"
-uuid = "9d5cd8c9-2029-5cab-9928-427838db53e3"
-version = "1.3.1"
-
 [deps]
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 FixedEffects = "c8885935-8500-56a7-9867-7708b20db0eb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Vcov = "ec2bfdc2-55df-4fc9-b9ae-4958c2cf2486"
 
 [compat]
+CSV = "0.8"
+CUDA = "1, 2"
 DataFrames = "0.21, 0.22"
 FixedEffects = "2"
 Reexport = "0.1, 0.2, 1.0"

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -1,0 +1,64 @@
+using CSV, DataFrames, Test
+using FixedEffectModels
+using FixedEffectModels: parse_fixedeffect, _multiply
+using FixedEffects
+import Base: ==
+
+==(x::FixedEffect{R,I}, y::FixedEffect{R,I}) where {R,I} =
+    x.refs == y.refs && x.interaction == y.interaction && x.n == y.n
+
+@testset "parse_fixedeffect" begin
+    csvfile = CSV.File(joinpath(dirname(pathof(FixedEffectModels)), "../dataset/Cigar.csv"))
+    df = DataFrame(csvfile)
+    # Any table type supporting the Tables.jl interface should work
+    for data in [df, csvfile]
+    	@test parse_fixedeffect(data, term(:Price)) === nothing
+        @test parse_fixedeffect(data, ConstantTerm(1)) === nothing
+        @test parse_fixedeffect(data, fe(:State)) == (FixedEffect(data.State), :fe_State)
+        
+    	@test parse_fixedeffect(data, fe(:State)&term(:Year)) ==
+            (FixedEffect(data.State, interaction=_multiply(data, [:Year])), Symbol("fe_State&Year"))
+        @test parse_fixedeffect(data, fe(:State)&fe(:Year)) ==
+            (FixedEffect(data.State, data.Year), Symbol("fe_State&fe_Year"))
+
+        @test parse_fixedeffect(data, ()) == (FixedEffect[], Symbol[], ())
+        
+        f = @formula(y ~ 1 + Price)
+        ts1 = f.rhs
+        ts2 = term(1) + term(:Price)
+        @test parse_fixedeffect(data, f) == (FixedEffect[], Symbol[], f)
+        @test parse_fixedeffect(data, ts1) == (FixedEffect[], Symbol[], ts1)
+        @test parse_fixedeffect(data, ts2) == parse_fixedeffect(data, ts1)
+
+        fparsed = term(:y) ~ InterceptTerm{false}() + term(:Price)
+        tsparsed = (InterceptTerm{false}(), term(:Price))
+
+        f = @formula(y ~ 1 + Price + fe(State))
+        ts1 = f.rhs
+        ts2 = term(1) + term(:Price) + fe(:State)
+        @test parse_fixedeffect(data, f) == ([FixedEffect(data.State)], [:fe_State], fparsed)
+        @test parse_fixedeffect(data, ts1) == ([FixedEffect(data.State)], [:fe_State], tsparsed)
+        @test parse_fixedeffect(data, ts2) == parse_fixedeffect(data, ts1)
+
+        f = @formula(y ~ Price + fe(State) + fe(Year))
+        ts1 = f.rhs
+        ts2 = term(:Price) + fe(:State) + fe(:Year)
+        @test parse_fixedeffect(data, f) == ([FixedEffect(data.State), FixedEffect(data.Year)], [:fe_State, :fe_Year], fparsed)
+        @test parse_fixedeffect(data, ts1) == ([FixedEffect(data.State), FixedEffect(data.Year)], [:fe_State, :fe_Year], tsparsed)
+        @test parse_fixedeffect(data, ts2) == parse_fixedeffect(data, ts1)
+
+        f = @formula(y ~ Price + fe(State)&Year)
+        ts1 = f.rhs
+        ts2 = term(:Price) + fe(:State)&term(:Year)
+        @test parse_fixedeffect(data, f) == ([FixedEffect(data.State, interaction=_multiply(data, [:Year]))], [Symbol("fe_State&Year")], term(:y) ~ (term(:Price),))
+        @test parse_fixedeffect(data, ts1) == ([FixedEffect(data.State, interaction=_multiply(data, [:Year]))], [Symbol("fe_State&Year")], (term(:Price),))
+        @test parse_fixedeffect(data, ts2) == parse_fixedeffect(data, ts1)
+
+        f = @formula(y ~ Price + fe(State)*fe(Year))
+        ts1 = f.rhs
+        ts2 = term(:Price) + fe(:State) + fe(:Year) + fe(:State)&fe(:Year)
+        @test parse_fixedeffect(data, f) == ([FixedEffect(data.State), FixedEffect(data.Year), FixedEffect(data.State, data.Year)], [:fe_State, :fe_Year, Symbol("fe_State&fe_Year")], fparsed)
+        @test parse_fixedeffect(data, ts1) == ([FixedEffect(data.State), FixedEffect(data.Year), FixedEffect(data.State, data.Year)], [:fe_State, :fe_Year, Symbol("fe_State&fe_Year")], tsparsed)
+        @test parse_fixedeffect(data, ts2) == parse_fixedeffect(data, ts1)
+    end
+end

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -1,6 +1,6 @@
 using CSV, DataFrames, Test
 using FixedEffectModels
-using FixedEffectModels: parse_fixedeffect, _multiply
+using FixedEffectModels: parse_fixedeffect, _parse_fixedeffect, _multiply
 using FixedEffects
 import Base: ==
 
@@ -12,13 +12,13 @@ import Base: ==
     df = DataFrame(csvfile)
     # Any table type supporting the Tables.jl interface should work
     for data in [df, csvfile]
-    	@test parse_fixedeffect(data, term(:Price)) === nothing
-        @test parse_fixedeffect(data, ConstantTerm(1)) === nothing
-        @test parse_fixedeffect(data, fe(:State)) == (FixedEffect(data.State), :fe_State)
+    	@test _parse_fixedeffect(data, term(:Price)) === nothing
+        @test _parse_fixedeffect(data, ConstantTerm(1)) === nothing
+        @test _parse_fixedeffect(data, fe(:State)) == (FixedEffect(data.State), :fe_State)
         
-    	@test parse_fixedeffect(data, fe(:State)&term(:Year)) ==
+    	@test _parse_fixedeffect(data, fe(:State)&term(:Year)) ==
             (FixedEffect(data.State, interaction=_multiply(data, [:Year])), Symbol("fe_State&Year"))
-        @test parse_fixedeffect(data, fe(:State)&fe(:Year)) ==
+        @test _parse_fixedeffect(data, fe(:State)&fe(:Year)) ==
             (FixedEffect(data.State, data.Year), Symbol("fe_State&fe_Year"))
 
         @test parse_fixedeffect(data, ()) == (FixedEffect[], Symbol[], ())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,11 @@
 using FixedEffectModels
 
-tests = ["fit.jl", 
+tests = [
+		 "formula.jl",
+		 "fit.jl", 
 		 "predict.jl", 
 		 "partial_out.jl"
-		 ]
+		]
 
 println("Running tests:")
 


### PR DESCRIPTION
I suggest making the following changes to `parse_fixedeffect`:

1. Avoid requiring the type of the data table `df` being a subtype of `AbstractDataFrame`.
2. Add a method for `NTuple{N, AbstractTerm}`.

The use of `DataFrames` is not crucial for the purposes of this package. However, it does add some unnecessary restrictions for external packages that use methods from this package. For now, I am only removing the use of `DataFrames` for `parse_fixedeffect`, as this function can immediately be used for other packages that also need to work with fixed effects.
