### PR TITLE
Added try/catch for IV standard errors

### DIFF
--- a/src/fit.jl
+++ b/src/fit.jl
@@ -227,7 +227,7 @@ function reg(
         iterations = maximum(iterations)
         converged = all(convergeds)
         if converged == false
-            @warn "convergence not achieved in $(iterations) iterations; try increasing maxiter or decreasing tol."
+            @warn "Convergence not achieved in $(iterations) iterations; try increasing maxiter or decreasing tol."
         end
 
         tss_partial = tss(y, has_intercept | has_fe_intercept, weights)
@@ -376,12 +376,18 @@ function reg(
             # requires too much memory
             p_kp = NaN
             F_kp = NaN
-         else
+        else
             Pip = Pi[(size(Pi, 1) - size(Z_res, 2) + 1):end, :]
-            r_kp = Vcov.ranktest!(Xendo_res, Z_res, Pip,
-                                  vcov_method, size(X, 2), dof_absorb)
-            p_kp = chisqccdf(size(Z_res, 2) - size(Xendo_res, 2) + 1, r_kp)
-            F_kp = r_kp / size(Z_res, 2)
+            try
+                r_kp = Vcov.ranktest!(Xendo_res, Z_res, Pip,
+                                      vcov_method, size(X, 2), dof_absorb)
+                p_kp = chisqccdf(size(Z_res, 2) - size(Xendo_res, 2) + 1, r_kp)
+                F_kp = r_kp / size(Z_res, 2)
+            catch
+                @warn "Standard errors for IV not estimated; ranktest failed"
+                p_kp = NaN
+                F_kp = NaN
+            end
         end
     end
     ##############################################################################


### PR DESCRIPTION
Sometimes Vcov.ranktest fail to compute standard errors for IV regressions.
Stata return results with warning.