### PR TITLE
Better printing

### DIFF
--- a/src/FixedEffectModel.jl
+++ b/src/FixedEffectModel.jl
@@ -41,7 +41,7 @@ struct FixedEffectModel <: RegressionModel
     F_kp::Union{Float64, Nothing}           # First Stage F statistics KP
     p_kp::Union{Float64, Nothing}           # First Stage p value KP
 
-    # msg
+    # message to display
     msg::Vector{String}
 end
 
@@ -237,7 +237,7 @@ function Base.show(io::IO, x::FixedEffectModel)
     widths .+= 1
     totalwidth = sum(widths) + rnwidth
     for msg in x.msg
-        println(msg)
+        println(io, msg)
     end
     if length(ctitle) > 0
         halfwidth = div(totalwidth - length(ctitle), 2)

--- a/src/FixedEffectModel.jl
+++ b/src/FixedEffectModel.jl
@@ -40,9 +40,6 @@ struct FixedEffectModel <: RegressionModel
     # for IV
     F_kp::Union{Float64, Nothing}           # First Stage F statistics KP
     p_kp::Union{Float64, Nothing}           # First Stage p value KP
-
-    # message to display
-    msg::Vector{String}
 end
 
 has_iv(x::FixedEffectModel) = x.F_kp !== nothing
@@ -236,9 +233,6 @@ function Base.show(io::IO, x::FixedEffectModel)
     end
     widths .+= 1
     totalwidth = sum(widths) + rnwidth
-    for msg in x.msg
-        println(io, msg)
-    end
     if length(ctitle) > 0
         halfwidth = div(totalwidth - length(ctitle), 2)
         println(io, " " ^ halfwidth * string(ctitle) * " " ^ halfwidth)

--- a/src/FixedEffectModel.jl
+++ b/src/FixedEffectModel.jl
@@ -40,6 +40,9 @@ struct FixedEffectModel <: RegressionModel
     # for IV
     F_kp::Union{Float64, Nothing}           # First Stage F statistics KP
     p_kp::Union{Float64, Nothing}           # First Stage p value KP
+
+    # msg
+    msg::Vector{String}
 end
 
 has_iv(x::FixedEffectModel) = x.F_kp !== nothing
@@ -233,6 +236,9 @@ function Base.show(io::IO, x::FixedEffectModel)
     end
     widths .+= 1
     totalwidth = sum(widths) + rnwidth
+    for msg in x.msg
+        println(msg)
+    end
     if length(ctitle) > 0
         halfwidth = div(totalwidth - length(ctitle), 2)
         println(io, " " ^ halfwidth * string(ctitle) * " " ^ halfwidth)

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -315,10 +315,6 @@ function reg(
         basis_coef = basis_Xexo
     end
 
-    #if !all(basis_coef)
-    #	out = join(coef_names[.!basis_coef], " ")
-    #    push!(msg, "Collinearities detected.", "Var(s) dropped: $(out)")
-    #end
     ##############################################################################
     ##
     ## Do the regression

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -280,7 +280,8 @@ function reg(
                             oldX[:, (length(basis_Xexo)+1):end][.!basisendo2], 
                             oldX[:, (length(basis_Xexo)+1):end][!basisendo2])
             end
-            println("Endogeneous vars are collinear with ivs. Var(s) recategorized as exogenous: ", join(coefendo_names[.!basis_endo2], " "))
+            out = join(coefendo_names[.!basis_endo2], " ")
+            @info "Endogeneous vars are collinear with ivs. Var(s) recategorized as exogenous: $(out)"
                                     
             # third pass
             basis = basecol(Xexo, Z, Xendo)
@@ -313,11 +314,6 @@ function reg(
         X = Xexo
         basis_coef = basis_Xexo
     end
-
-    if !all(basis_coef)
-        println("Collinearities detected. Var(s) dropped: ", join(coef_names[.!basis_coef], " "))
-    end
-
 
     ##############################################################################
     ##

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -250,6 +250,7 @@ function reg(
     ## Get Linearly Independent Components of Matrix
     ##
     ##############################################################################
+    msg = String[]
     # Compute linearly independent columns + create the Xhat matrix
     if has_iv    	
         # first pass: remove colinear variables in Xendo
@@ -281,7 +282,7 @@ function reg(
                             oldX[:, (length(basis_Xexo)+1):end][!basisendo2])
             end
             out = join(coefendo_names[.!basis_endo2], " ")
-            @info "Endogeneous vars are collinear with ivs. Var(s) recategorized as exogenous: $(out)"
+            push!(msg, "Endogenous vars collinear with ivs", "Recategorized as exogenous: $(out)")
                                     
             # third pass
             basis = basecol(Xexo, Z, Xendo)
@@ -315,6 +316,10 @@ function reg(
         basis_coef = basis_Xexo
     end
 
+    if !all(basis_coef)
+    	out = join(coef_names[.!basis_coef], " ")
+        push!(msg, "Collinearities detected.", "Var(s) dropped: $(out)")
+    end
     ##############################################################################
     ##
     ## Do the regression
@@ -428,5 +433,5 @@ function reg(
     if esample == Colon()
         esample = trues(N)
     end
-    return FixedEffectModel(coef, matrix_vcov, vcov, nclusters, esample, residuals2, augmentdf, coef_names, response_name, formula_origin, formula, contrasts, nobs, dof_residual_,  rss, tss_total, r2, adjr2, F, p, iterations, converged, r2_within, F_kp, p_kp)
+    return FixedEffectModel(coef, matrix_vcov, vcov, nclusters, esample, residuals2, augmentdf, coef_names, response_name, formula_origin, formula, contrasts, nobs, dof_residual_,  rss, tss_total, r2, adjr2, F, p, iterations, converged, r2_within, F_kp, p_kp, msg)
 end

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -250,7 +250,6 @@ function reg(
     ## Get Linearly Independent Components of Matrix
     ##
     ##############################################################################
-    msg = String[]
     # Compute linearly independent columns + create the Xhat matrix
     if has_iv    	
         # first pass: remove colinear variables in Xendo
@@ -282,7 +281,7 @@ function reg(
                             oldX[:, (length(basis_Xexo)+1):end][!basisendo2])
             end
             out = join(coefendo_names[.!basis_endo2], " ")
-            push!(msg, "Endogenous vars collinear with ivs", "Recategorized as exogenous: $(out)")
+            @info "Endogenous vars collinear with ivs. Recategorized as exogenous: $(out)"
                                     
             # third pass
             basis = basecol(Xexo, Z, Xendo)
@@ -316,10 +315,10 @@ function reg(
         basis_coef = basis_Xexo
     end
 
-    if !all(basis_coef)
-    	out = join(coef_names[.!basis_coef], " ")
-        push!(msg, "Collinearities detected.", "Var(s) dropped: $(out)")
-    end
+    #if !all(basis_coef)
+    #	out = join(coef_names[.!basis_coef], " ")
+    #    push!(msg, "Collinearities detected.", "Var(s) dropped: $(out)")
+    #end
     ##############################################################################
     ##
     ## Do the regression
@@ -433,5 +432,5 @@ function reg(
     if esample == Colon()
         esample = trues(N)
     end
-    return FixedEffectModel(coef, matrix_vcov, vcov, nclusters, esample, residuals2, augmentdf, coef_names, response_name, formula_origin, formula, contrasts, nobs, dof_residual_,  rss, tss_total, r2, adjr2, F, p, iterations, converged, r2_within, F_kp, p_kp, msg)
+    return FixedEffectModel(coef, matrix_vcov, vcov, nclusters, esample, residuals2, augmentdf, coef_names, response_name, formula_origin, formula, contrasts, nobs, dof_residual_,  rss, tss_total, r2, adjr2, F, p, iterations, converged, r2_within, F_kp, p_kp)
 end

--- a/src/utils/basecol.jl
+++ b/src/utils/basecol.jl
@@ -68,18 +68,16 @@ function invsym!(X::AbstractMatrix)
         else
             X[j,:] = X[j,:] ./ d
             for i in 1:size(X, 1)
-                if (i != j)
+                if i != j
                     X[i,:] .= X[i,:] .- X[i,j] .* X[j,:]
                     X[i,j] = -X[i,j] / d
                 end
             end
-            X[j,j] = 1/d
+            X[j,j] = 1 / d
         end
     end
     return X
 end
-
-
 
 function getcols(X::AbstractMatrix,  basecolX::AbstractVector)
     sum(basecolX) == size(X, 2) ? X : X[:, basecolX]


### PR DESCRIPTION
Use info for endogenous reclassified as exogenous. Print nothing for collinearity.