### PR TITLE
Fix typo when saving residuals

### DIFF
--- a/src/fit.jl
+++ b/src/fit.jl
@@ -337,7 +337,7 @@ function reg(
     if save_residuals
         residuals2 = Vector{Union{Float64, Missing}}(missing, N)
         if has_weights
-            residuals .= residuals ./ sqrt.(weights)
+            residuals2 .= residuals ./ sqrt.(weights)
         end
         residuals2[esample] = residuals
     end

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -337,9 +337,10 @@ function reg(
     if save_residuals
         residuals2 = Vector{Union{Float64, Missing}}(missing, N)
         if has_weights
-            residuals2 .= residuals ./ sqrt.(weights)
+            residuals2[esample] .= residuals ./ sqrt.(weights)
+        else
+            residuals2[esample] .= residuals
         end
-        residuals2[esample] = residuals
     end
 
     augmentdf = DataFrame()

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -449,6 +449,10 @@ x = reg(df, m)
 @test r2(x) ≈ 0.0969 atol = 1e-4
 @test adjr2(x) ≈ 0.09622618 atol = 1e-4
 
+df = DataFrame(CSV.File(joinpath(dirname(pathof(FixedEffectModels)), "../dataset/Cigar.csv")))
+x = reg(df, @formula(Sales ~ NDI + fe(State) + fe(Year)), Vcov.cluster(:State), save = :residuals, weights = :Pop)
+@test r2(x) ≈ 0.802777 atol = 1e-4
+
 ##############################################################################
 ##
 ## F Stat


### PR DESCRIPTION
```
using DataFrames, RDatasets, FixedEffectModels
df = dataset("plm", "Cigar")
result = reg(df, @formula(Sales ~ NDI + fe(State) + fe(Year)), Vcov.cluster(:State))
```
yields (all good!):

Number of obs:                 1380  Degrees of freedom:              32
R2:                           ***0.803***  R2 Adjusted:                  ***0.798***
F-Stat:                     13.3382  p-value:                      0.001
R2 within:                    ***0.139***  Iterations:                       5

But saving the residuals:
```
using DataFrames, RDatasets, FixedEffectModels
df = dataset("plm", "Cigar")
result = reg(df, @formula(Sales ~ NDI + fe(State) + fe(Year)), Vcov.cluster(:State), save = :residuals, weights = :Pop)
```

messes up the `residuals`:

Number of obs:                1380   Degrees of freedom:             32
R2:                          ***1.000***   R2 Adjusted:                 ***1.000***
F-Stat:                    52074.5   p-value:                     0.000
R2 within:                   ***1.000***   Iterations:                      5
