### PR TITLE
Add loglikelihood and nullloglikelihood

### DIFF
--- a/src/FixedEffectModel.jl
+++ b/src/FixedEffectModel.jl
@@ -24,7 +24,7 @@ struct FixedEffectModel <: RegressionModel
     contrasts::Dict
 
     nobs::Int64             # Number of observations
-    dof::Int64              # Number parameters estimated - has_intercept. Used for p-value of F-stat.
+    dof::Int64              # Number parameters estimated + fixed effects - has_intercept.
     dof_residual::Int64     # dof used for t-test and p-value of F-stat. nobs - degrees of freedoms with simple std
     rss::Float64            # Sum of squared residuals
     tss::Float64            # Total sum of squares

--- a/src/FixedEffectModel.jl
+++ b/src/FixedEffectModel.jl
@@ -64,6 +64,25 @@ StatsAPI.rss(m::FixedEffectModel) = m.rss
 StatsAPI.mss(m::FixedEffectModel) = deviance(m) - rss(m)
 StatsModels.formula(m::FixedEffectModel) = m.formula_schema
 
+function StatsAPI.loglikelihood(m::FixedEffectModel)
+    n = nobs(m)
+    -n/2 * (log(2π * rss(m) / n) + 1)
+end
+
+function StatsAPI.nullloglikelihood(m::FixedEffectModel)
+    n = nobs(m)
+    -n/2 * (log(2π * deviance(m) / n) + 1)
+end
+
+# Stata reghdfe reports nullloglikelood after fixed effects are dealt with
+# and some of R fixest estimates also use loglikelihood with only fixed
+# effects in the regression
+function nullloglikelihood_within(m::FixedEffectModel)
+    n = nobs(m)
+    tss_within = rss(m) / (1 - m.r2_within)
+    -n/2 * (log(2π * tss_within / n) + 1)
+end
+
 function StatsAPI.confint(m::FixedEffectModel; level::Real = 0.95)
     scale = tdistinvcdf(StatsAPI.dof_residual(m), 1 - (1 - level) / 2)
     se = stderror(m)

--- a/src/FixedEffectModel.jl
+++ b/src/FixedEffectModel.jl
@@ -64,7 +64,7 @@ StatsAPI.deviance(m::FixedEffectModel) = m.tss
 StatsAPI.rss(m::FixedEffectModel) = m.rss
 StatsAPI.mss(m::FixedEffectModel) = deviance(m) - rss(m)
 StatsModels.formula(m::FixedEffectModel) = m.formula_schema
-dof_fe(m::FixedEffectModel) = m.dof_fes
+dof_fes(m::FixedEffectModel) = m.dof_fes
 
 function StatsAPI.loglikelihood(m::FixedEffectModel)
     n = nobs(m)
@@ -86,7 +86,7 @@ function nullloglikelihood_within(m::FixedEffectModel)
 end
 
 function StatsAPI.adjr2(model::FixedEffectModel, variant::Symbol)
-    k = dof(model) + dof_fe(model)
+    k = dof(model) + dof_fes(model) - has_fe(model)
     if variant == :McFadden
         ll = loglikelihood(model)
         ll0 = nullloglikelihood(model)

--- a/src/FixedEffectModels.jl
+++ b/src/FixedEffectModels.jl
@@ -26,7 +26,7 @@ include("partial_out.jl")
 
 # Export from StatsBase
 export coef, coefnames, coeftable, responsename, vcov, stderror, nobs, dof_residual, r2, adjr2, islinear, deviance, rss, mss, confint, predict, residuals, fit,
-    loglikelihood, nullloglikelihood
+    loglikelihood, nullloglikelihood, dof_fes
 
 export reg,
 partial_out,

--- a/src/FixedEffectModels.jl
+++ b/src/FixedEffectModels.jl
@@ -25,7 +25,8 @@ include("fit.jl")
 include("partial_out.jl")
 
 # Export from StatsBase
-export coef, coefnames, coeftable, responsename, vcov, stderror, nobs, dof_residual, r2, adjr2, islinear, deviance, rss, mss, confint, predict, residuals, fit
+export coef, coefnames, coeftable, responsename, vcov, stderror, nobs, dof_residual, r2, adjr2, islinear, deviance, rss, mss, confint, predict, residuals, fit,
+    loglikelihood, nullloglikelihood
 
 export reg,
 partial_out,

--- a/src/FixedEffectModels.jl
+++ b/src/FixedEffectModels.jl
@@ -25,7 +25,7 @@ include("fit.jl")
 include("partial_out.jl")
 
 # Export from StatsBase
-export coef, coefnames, coeftable, responsename, vcov, stderror, nobs, dof_residual, r2, adjr2, islinear, deviance, rss, mss, confint, predict, residuals, fit,
+export coef, coefnames, coeftable, responsename, vcov, stderror, nobs, dof_residual, r2, adjr2, islinear, deviance, nulldeviance, rss, mss, confint, predict, residuals, fit,
     loglikelihood, nullloglikelihood, dof_fes
 
 export reg,

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -18,7 +18,6 @@ Estimate a linear model with high dimensional categorical variables / instrument
 * `drop_singletons::Bool = true`: Should singletons be dropped?
 * `progress_bar::Bool = true`: Should the regression show a progressbar?
 * `first_stage::Bool = true`: Should the first-stage F-stat and p-value be computed?
-* `dof_add::Integer = 0`: 
 * `subset::Union{Nothing, AbstractVector} = nothing`: select specific rows. 
 
 
@@ -450,13 +449,13 @@ function StatsAPI.fit(::Type{FixedEffectModel},
     end
 
     # Compute standard error
-    vcov_data = Vcov.VcovData(Xhat, crossx, residuals, nobs - size(X, 2) - dof_fes - dof_add)
+    vcov_data = Vcov.VcovData(Xhat, crossx, residuals, nobs - size(X, 2) - dof_fes)
     matrix_vcov = StatsAPI.vcov(vcov_data, vcov_method)
 
     # Compute Fstat
     F = Fstat(coef, matrix_vcov, has_intercept)
     # dof_ is the number of estimated coefficients beyond the intercept.
-    dof_ = size(X, 2) - has_intercept + dof_add
+    dof_ = size(X, 2) - has_intercept
     dof_tstat_ = max(1, Vcov.dof_residual(vcov_data, vcov_method) - has_intercept | has_fe_intercept)
     p = fdistccdf(dof_, dof_tstat_, F)
     # Compute Fstat of First Stage

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -429,7 +429,7 @@ function StatsAPI.fit(::Type{FixedEffectModel},
     ##
     ##############################################################################
     # Compute degrees of freedom
-    dof_model_and_fes = 0
+    dof_fes_total = 0
     dof_fes = 0
     if has_fes
         for fe in fes
@@ -440,7 +440,7 @@ function StatsAPI.fit(::Type{FixedEffectModel},
                 #only count groups that exists
                 dof_fes += nunique(fe)
             end
-            dof_model_and_fes += nunique(fe)
+            dof_fes_total += nunique(fe)
         end
     end
 
@@ -457,7 +457,6 @@ function StatsAPI.fit(::Type{FixedEffectModel},
     F = Fstat(coef, matrix_vcov, has_intercept)
     # dof_ is the number of estimated coefficients beyond the intercept.
     dof_ = size(X, 2) - has_intercept
-    dof_model_and_fes += dof_ - has_fe_intercept
     dof_tstat_ = max(1, Vcov.dof_residual(vcov_data, vcov_method) - has_intercept | has_fe_intercept)
     p = fdistccdf(dof_, dof_tstat_, F)
     # Compute Fstat of First Stage
@@ -478,7 +477,7 @@ function StatsAPI.fit(::Type{FixedEffectModel},
     rss = sum(abs2, residuals)
     mss = tss_total - rss
     r2 = 1 - rss / tss_total
-    adjr2 = 1 - rss / tss_total * (nobs - (has_intercept | has_fe_intercept)) / max(nobs - size(X, 2) - dof_fes - dof_add, 1)
+    adjr2 = 1 - rss / tss_total * (nobs - (has_intercept | has_fe_intercept)) / max(nobs - size(X, 2) - dof_fes_total - dof_add, 1)
     if has_fes
         r2_within = 1 - rss / tss_partial
     end
@@ -518,5 +517,5 @@ function StatsAPI.fit(::Type{FixedEffectModel},
     if esample == Colon()
         esample = trues(N)
     end
-    return FixedEffectModel(coef, matrix_vcov, vcov, nclusters, esample, residuals2, augmentdf, fekeys, coef_names, response_name, formula_origin, formula_schema, contrasts, nobs, dof_model_and_fes, dof_tstat_, rss, tss_total, r2, adjr2, F, p, iterations, converged, r2_within, F_kp, p_kp)
+    return FixedEffectModel(coef, matrix_vcov, vcov, nclusters, esample, residuals2, augmentdf, fekeys, coef_names, response_name, formula_origin, formula_schema, contrasts, nobs, dof_, dof_fes_total, dof_tstat_, rss, tss_total, r2, adjr2, F, p, iterations, converged, r2_within, F_kp, p_kp)
 end

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -456,7 +456,7 @@ function StatsAPI.fit(::Type{FixedEffectModel},
     # Compute Fstat
     F = Fstat(coef, matrix_vcov, has_intercept)
     # dof_ is the number of estimated coefficients beyond the intercept.
-    dof_ = size(X, 2) - has_intercept
+    dof_ = size(X, 2) - has_intercept + dof_add
     dof_tstat_ = max(1, Vcov.dof_residual(vcov_data, vcov_method) - has_intercept | has_fe_intercept)
     p = fdistccdf(dof_, dof_tstat_, F)
     # Compute Fstat of First Stage
@@ -473,11 +473,9 @@ function StatsAPI.fit(::Type{FixedEffectModel},
         end
     end
 
-    # Compute rss, tss, r2, r2 adjusted
+    # Compute rss, tss
     rss = sum(abs2, residuals)
     mss = tss_total - rss
-    r2 = 1 - rss / tss_total
-    adjr2 = 1 - rss / tss_total * (nobs - (has_intercept | has_fe_intercept)) / max(nobs - size(X, 2) - dof_fes_total - dof_add, 1)
     if has_fes
         r2_within = 1 - rss / tss_partial
     end
@@ -517,5 +515,5 @@ function StatsAPI.fit(::Type{FixedEffectModel},
     if esample == Colon()
         esample = trues(N)
     end
-    return FixedEffectModel(coef, matrix_vcov, vcov, nclusters, esample, residuals2, augmentdf, fekeys, coef_names, response_name, formula_origin, formula_schema, contrasts, nobs, dof_, dof_fes_total, dof_tstat_, rss, tss_total, r2, adjr2, F, p, iterations, converged, r2_within, F_kp, p_kp)
+    return FixedEffectModel(coef, matrix_vcov, vcov, nclusters, esample, residuals2, augmentdf, fekeys, coef_names, response_name, formula_origin, formula_schema, contrasts, nobs, dof_, dof_fes_total, dof_tstat_, rss, tss_total, F, p, iterations, converged, r2_within, F_kp, p_kp)
 end

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -429,6 +429,7 @@ function StatsAPI.fit(::Type{FixedEffectModel},
     ##
     ##############################################################################
     # Compute degrees of freedom
+    dof_model_and_fes = 0
     dof_fes = 0
     if has_fes
         for fe in fes
@@ -439,6 +440,7 @@ function StatsAPI.fit(::Type{FixedEffectModel},
                 #only count groups that exists
                 dof_fes += nunique(fe)
             end
+            dof_model_and_fes += nunique(fe)
         end
     end
 
@@ -455,6 +457,7 @@ function StatsAPI.fit(::Type{FixedEffectModel},
     F = Fstat(coef, matrix_vcov, has_intercept)
     # dof_ is the number of estimated coefficients beyond the intercept.
     dof_ = size(X, 2) - has_intercept
+    dof_model_and_fes += dof_ - has_fe_intercept
     dof_tstat_ = max(1, Vcov.dof_residual(vcov_data, vcov_method) - has_intercept | has_fe_intercept)
     p = fdistccdf(dof_, dof_tstat_, F)
     # Compute Fstat of First Stage
@@ -515,6 +518,5 @@ function StatsAPI.fit(::Type{FixedEffectModel},
     if esample == Colon()
         esample = trues(N)
     end
-    dof_out = dof_fes == 0 ? dof_ : dof_fes
-    return FixedEffectModel(coef, matrix_vcov, vcov, nclusters, esample, residuals2, augmentdf, fekeys, coef_names, response_name, formula_origin, formula_schema, contrasts, nobs, dof_out, dof_tstat_, rss, tss_total, r2, adjr2, F, p, iterations, converged, r2_within, F_kp, p_kp)
+    return FixedEffectModel(coef, matrix_vcov, vcov, nclusters, esample, residuals2, augmentdf, fekeys, coef_names, response_name, formula_origin, formula_schema, contrasts, nobs, dof_model_and_fes, dof_tstat_, rss, tss_total, r2, adjr2, F, p, iterations, converged, r2_within, F_kp, p_kp)
 end

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -515,6 +515,6 @@ function StatsAPI.fit(::Type{FixedEffectModel},
     if esample == Colon()
         esample = trues(N)
     end
-
-    return FixedEffectModel(coef, matrix_vcov, vcov, nclusters, esample, residuals2, augmentdf, fekeys, coef_names, response_name, formula_origin, formula_schema, contrasts, nobs, dof_, dof_tstat_, rss, tss_total, r2, adjr2, F, p, iterations, converged, r2_within, F_kp, p_kp)
+    dof_out = dof_fes == 0 ? dof_ : dof_fes
+    return FixedEffectModel(coef, matrix_vcov, vcov, nclusters, esample, residuals2, augmentdf, fekeys, coef_names, response_name, formula_origin, formula_schema, contrasts, nobs, dof_out, dof_tstat_, rss, tss_total, r2, adjr2, F, p, iterations, converged, r2_within, F_kp, p_kp)
 end

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -458,6 +458,10 @@ end
 	x = reg(df, m)
 	@test r2(x) ≈ 0.0969 atol = 1e-4
 	@test adjr2(x) ≈ 0.09622618 atol = 1e-4
+	m = @formula Sales ~ Price + Pimin + fe(State)
+	x = reg(df, m, Vcov.cluster(:State))
+	@test r2(x) ≈ 0.77472 atol = 1e-4
+	@test adjr2(x) ≈ 0.766768 atol = 1e-4
 
 
 	##############################################################################
@@ -590,7 +594,7 @@ end
 	@test nullloglikelihood(x) ≈ -6696.1387 atol = 1e-4
 	@test nullloglikelihood_within(x) ≈ -5891.2836 atol = 1e-4
 	@test r2(x, :McFadden) ≈ 0.15358 atol = 1e-4 # Pseudo R2 in R fixest
-	@test adjr2(x, :McFadden) ≈ 0.14656 atol = 1e-4
+	@test adjr2(x, :McFadden) ≈ 0.14641 atol = 1e-4
 
 end
 

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -561,6 +561,35 @@ end
 	m = @formula Sales ~ (Price ~ Pimin + CPI)
 	x = reg(df, m, Vcov.cluster(:State, :Year))
 	@test x.F_kp  ≈ 2873.1405 atol = 1e-4
+
+	############################################
+	##
+	## loglikelihood and related
+	##
+	############################################
+
+	m = @formula(Sales ~ Price)
+	x = reg(df, m, Vcov.cluster(:State))
+	@test loglikelihood(x) ≈ -6625.8266 atol = 1e-4
+	@test nullloglikelihood(x) ≈ -6696.1387 atol = 1e-4
+	@test r2(x, :McFadden) ≈ 0.01050 atol = 1e-4 # Pseudo R2 in R fixest
+	@test adjr2(x, :McFadden) ≈ 0.01035 atol = 1e-4
+
+	m = @formula(Sales ~ Price + Pimin)
+	x = reg(df, m)
+	@test loglikelihood(x) ≈ -6598.6300 atol = 1e-4
+	@test nullloglikelihood(x) ≈ -6696.1387 atol = 1e-4
+	@test r2(x, :McFadden) ≈ 0.01456 atol = 1e-4 # Pseudo R2 in R fixest
+	@test adjr2(x, :McFadden) ≈ 0.01426 atol = 1e-4
+
+	m = @formula(Sales ~ Price + Pimin + fe(State))
+	x = reg(df, m)
+	@test loglikelihood(x) ≈ -5667.7629 atol = 1e-4
+	@test nullloglikelihood(x) ≈ -6696.1387 atol = 1e-4
+	@test FixedEffectModels.nullloglikelihood_within(x) = -5891.2836 atol = 1e-4
+	@test r2(x, :McFadden) ≈ 0.15358 atol = 1e-4 # Pseudo R2 in R fixest
+	@test adjr2(x, :McFadden) ≈ 0.14656 atol = 1e-4
+
 end
 
 

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -594,7 +594,7 @@ end
 	@test nullloglikelihood(x) ≈ -6696.1387 atol = 1e-4
 	@test nullloglikelihood_within(x) ≈ -5891.2836 atol = 1e-4
 	@test r2(x, :McFadden) ≈ 0.15358 atol = 1e-4 # Pseudo R2 in R fixest
-	@test adjr2(x, :McFadden) ≈ 0.14641 atol = 1e-4
+	@test adjr2(x, :McFadden) ≈ 0.14656 atol = 1e-4
 
 end
 

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -1,5 +1,5 @@
 using CUDA, FixedEffectModels, CategoricalArrays, CSV, DataFrames, Test, LinearAlgebra
-
+using FixedEffectModels: nullloglikelihood_within
 
 
 ##############################################################################
@@ -566,6 +566,8 @@ end
 	##
 	## loglikelihood and related
 	##
+	## tested with clusters since those should not
+	## affect the results
 	############################################
 
 	m = @formula(Sales ~ Price)
@@ -576,17 +578,17 @@ end
 	@test adjr2(x, :McFadden) ≈ 0.01035 atol = 1e-4
 
 	m = @formula(Sales ~ Price + Pimin)
-	x = reg(df, m)
+	x = reg(df, m, Vcov.cluster(:State))
 	@test loglikelihood(x) ≈ -6598.6300 atol = 1e-4
 	@test nullloglikelihood(x) ≈ -6696.1387 atol = 1e-4
 	@test r2(x, :McFadden) ≈ 0.01456 atol = 1e-4 # Pseudo R2 in R fixest
 	@test adjr2(x, :McFadden) ≈ 0.01426 atol = 1e-4
 
 	m = @formula(Sales ~ Price + Pimin + fe(State))
-	x = reg(df, m)
+	x = reg(df, m, Vcov.cluster(:State))
 	@test loglikelihood(x) ≈ -5667.7629 atol = 1e-4
 	@test nullloglikelihood(x) ≈ -6696.1387 atol = 1e-4
-	@test FixedEffectModels.nullloglikelihood_within(x) = -5891.2836 atol = 1e-4
+	@test nullloglikelihood_within(x) ≈ -5891.2836 atol = 1e-4
 	@test r2(x, :McFadden) ≈ 0.15358 atol = 1e-4 # Pseudo R2 in R fixest
 	@test adjr2(x, :McFadden) ≈ 0.14656 atol = 1e-4
 


### PR DESCRIPTION
Add StatsAPI functions related to loglikelihood and nullloglikelihood. These are necessary for computing some R-squared values (McFadden, etc.), so those are also tested.

The only breaking change in this is a change to dof. Currently, the reported dof is the number of parameters in the model. In order to correctly compute some of the adjusted R-squared values based on loglikelihood, this needs to be the total number of coefficients in the model including the fixed effects