### PR TITLE
Add drop_singletons option to partial_out()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
 
 benchmark/.sublime2Terminal.jl
 .vscode/settings.json
-Manifest.toml
-debug/debug.jl
-debug/pseudoreg.csv
-debug/repl.do

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 
 benchmark/.sublime2Terminal.jl
 .vscode/settings.json
+Manifest.toml
+debug/debug.jl
+debug/pseudoreg.csv
+debug/repl.do

--- a/src/partial_out.jl
+++ b/src/partial_out.jl
@@ -10,6 +10,7 @@ Partial out variables in a Dataframe
 * `double_precision::Bool`: Should the demeaning operation use Float64 rather than Float32? Default to true.
 * `tol::Real`: Tolerance
 * `align::Bool`: Should the returned DataFrame align with the original DataFrame in case of missing values? Default to true.
+* `drop_singletons::Bool=false`: Should singletons be dropped?
 
 ### Returns
 * `::DataFrame`: a dataframe with as many columns as there are dependent variables and as many rows as the original dataframe.
@@ -40,7 +41,8 @@ function partial_out(
     @nospecialize(method::Symbol = :cpu),
     @nospecialize(double_precision::Bool = true),
     @nospecialize(tol::Real = double_precision ? 1e-8 : 1e-6),
-    @nospecialize(align = true))
+    @nospecialize(align = true),
+    @nospecialize(drop_singletons = false))
 
     if  (ConstantTerm(0) ∉ eachterm(f.rhs)) & (ConstantTerm(1) ∉ eachterm(f.rhs))
         f = FormulaTerm(f.lhs, tuple(ConstantTerm(1), eachterm(f.rhs)...))
@@ -67,6 +69,7 @@ function partial_out(
     fes, ids, ids_fes = parse_fixedeffect(df, formula_fes)
     has_fes = !isempty(fes)
 
+    drop_singletons && drop_singletons!(esample, fes, Threads.nthreads())
 
     nobs = sum(esample)
     (nobs > 0) || throw("sample is empty")

--- a/src/partial_out.jl
+++ b/src/partial_out.jl
@@ -138,6 +138,8 @@ function partial_out(
         residuals .= residuals .+ m
     end
 
+    dof_fes = mapreduce(nunique, +, fes, init=0)
+
     # Return a dataframe
     out = DataFrame()
     j = 0
@@ -151,5 +153,5 @@ function partial_out(
             out[!, Symbol(y)] = residuals[:, j]
         end
     end
-    return out, esample, iterations, convergeds
+    return out, esample, iterations, convergeds, dof_fes
 end


### PR DESCRIPTION
Before handing things over to `ivreg2`, `ivregdfe` partials out the FE _and_ identifies and drops singletons. I'm making `reghdfejl` optionally do the same thing now--call partial_out() and then use ivreg2 instead of FixedEffectsModels.jl for the core IV work--since it offers a lot more diagnostics and estimation options. So it would be good if `partial_out()` also optionally dropped singletons. I made the new `drop_singletons` option default to false so old results are not affected. Of course, this is inconsistent with the default for `drop_singletons` being `true` in fit().
